### PR TITLE
Potential fix for code scanning alert no. 3: Server-side request forgery

### DIFF
--- a/app/api/calendar/delete-event.ts
+++ b/app/api/calendar/delete-event.ts
@@ -16,6 +16,11 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
   if (!eventId) {
     return res.status(400).json({ error: "ID de l'événement requis" });
   }
+  // Validation de l'ID de l'événement
+  const eventIdPattern = /^[a-zA-Z0-9_-]+$/; // Autorise uniquement les caractères alphanumériques, tirets et underscores
+  if (!eventIdPattern.test(eventId)) {
+    return res.status(400).json({ error: "ID de l'événement invalide" });
+  }
 
   try {
     // Requête DELETE à l'API Google Calendar pour supprimer l'événement


### PR DESCRIPTION
Potential fix for [https://github.com/No1ceTea/cani-sport-eure/security/code-scanning/3](https://github.com/No1ceTea/cani-sport-eure/security/code-scanning/3)

To fix the issue, we need to validate and sanitize the `eventId` parameter before using it in the URL. Since `eventId` is expected to be a specific identifier for a calendar event, we can enforce strict validation rules to ensure it conforms to the expected format. For example, we can use a regular expression to validate that `eventId` contains only alphanumeric characters, dashes, or underscores, which are typical for such identifiers.

Steps to implement the fix:
1. Add a validation step for `eventId` to ensure it matches the expected format.
2. If the validation fails, return a `400 Bad Request` response with an appropriate error message.
3. Only proceed with the `axios.delete` request if the validation passes.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
